### PR TITLE
Making it possible to only run forward (without retro step)

### DIFF
--- a/synspace/synspace.py
+++ b/synspace/synspace.py
@@ -217,7 +217,7 @@ def forward(
                     props.append(
                         {
                             "rxn-name": n.replace("_", " "),
-                            "rxn": f"{s}>>{smi}",
+                            "rxn": f"{rsmi}>>{s}",
                             "match": match,
                         }
                     )


### PR DESCRIPTION
Fixing https://github.com/whitead/synspace/issues/3. 

plus using `reos_filters` only if `filter==True`.